### PR TITLE
Use kubeflow-news tag

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -7,24 +7,24 @@
 
   <header class="p-strip--dark p-strip--image" style="text-align: left">
     <div class="row">
-      <div class="col-8">    
+      <div class="col-8">
         <h1>Kubeflow news</h1>
       </div>
     </div>
-    
+
     <div class="row">
       <div class="col-8">
         <h2 class="p-heading--four">Your weekly update of curated kubeflow news from across the web.</h2>
       </div>
     </div>
   </header>
-  
+
   <section class="p-strip">
     <div class="row">
       <div class="col-7">
         {% for article in articles %}
           <article>
-            <h1 class="p-heading--two u-no-margin--bottom u-sv1">{{ article.title.rendered }}</h1>
+            <h1 class="p-heading--two u-no-margin--bottom u-sv1">{{ article.title.rendered|safe }}</h1>
             <p>{{ article.date }}</p>
 
             {{ article.content.rendered|safe }}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -17,8 +17,8 @@ blog = BlogExtension(
     # app, "kubeflow-news.com", [3408], "kubeflow-news", "/", [3184, 3265]
     app,
     "kubeflow-news.com",
-    [1239],
-    "design",
+    [3408],
+    "kubeflow-news",
     "/",
     [3184, 3265],
 )


### PR DESCRIPTION
## Done 

- Switched site to use the kubeflow-news (3408) tag
- Posted the test article
- Confirmed it isn't on cn.u.c/blog, jp.u.c/blog and u.c/blog

## QA 

- download this branch
- ./run the site
- see there is a single post on http://0.0.0.0:8035/
- see that the feed looks like it has the same post (only) http://0.0.0.0:8035/feed

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1436