### PR TITLE
Centre images in blog posts

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -21,3 +21,9 @@
 @include kubeflow-news-p-navigation;
 @include kubeflow-news-p-separator;
 @include kubeflow-news-p-strip;
+
+/*Centre images in blog posts*/
+figure {
+    @extend %max-width--p;
+    text-align: center;
+  }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -22,7 +22,7 @@
 @include kubeflow-news-p-separator;
 @include kubeflow-news-p-strip;
 
-/*Centre images in blog posts*/
+// Centre images in blog posts
 figure {
   @extend %max-width--p;
   text-align: center;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -24,6 +24,6 @@
 
 /*Centre images in blog posts*/
 figure {
-    @extend %max-width--p;
-    text-align: center;
-  }
+  @extend %max-width--p;
+  text-align: center;
+}


### PR DESCRIPTION
## Done

Added CSS to centre images in blog posts.

## QA
- Check out this branch.
- View page locally at http://0.0.0.0:8035/
- Ensure that all images are centred.

## Fixes
Fixes issue #19 