### PR TITLE
Fix broken legal links on newsletter signup

### DIFF
--- a/templates/blog/_newsletter-signup-form.html
+++ b/templates/blog/_newsletter-signup-form.html
@@ -11,7 +11,7 @@
       </div>
 
       <p>
-        <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
+        <small>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</small>
       </p>
 
       <p class="u-no-margin--bottom">


### PR DESCRIPTION
## QA

- Run local site
- Check legal links under newsletter signup do not 404