### PR TITLE
Bump blog module to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==0.3.1
-canonicalwebteam.blog==2.2.1
+canonicalwebteam.blog==2.4.0
 Flask==1.1.1


### PR DESCRIPTION
## Done

- bumped the blog module to 2.4.0

## QA

- pull this branch
- goto http://0.0.0.0:8035/feed and see that the feed points back to http://0.0.0.0:8035/XXX and not admin.insights.ubuntu.com