### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Don't include caches, logs and documentation
+*.log
+.circleci
+.codecov
+.git
+.github
+.gitignore
+.vscode
+cache.sqlite
+README.md
+HACKING.md
+
+# The run script isn't needed
+run
+.docker-project
+
+# Environemnt
+.env
+.env.local
+
+# Node is only needed for building, not running
+package.json
+node_modules
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes python3-pip
+RUN apt-get update -y && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
 
 # Set git commit ID
 ARG TALISKER_REVISION_ID
 ENV TALISKER_REVISION_ID "${TALISKER_REVISION_ID}"
 
 # Import code, install code dependencies
-ADD . .
-RUN pip3 install -r requirements.txt
+COPY . .
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
Reduce size of docker image

## QA
- on `master` run `docker build -t kubeflow-news.com:master .`
- checkout this feature branch
- run `docker build -t kubeflow-news.com:feature .`
- run `docker images` and see the image tagged as `feature` is smaller than `master`
- run `docker run -ti -p 8035:80 kubeflow-news.com:feature`
- browse localhost:8035 and make sure the site works