### PR TITLE
Add link to ubuntu.com kubelfow page in footer

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -3,7 +3,7 @@
     <div class="col-8">
       <img class="p-footer__logo" src="https://assets.ubuntu.com/v1/6daed065-icon-canonical.svg" alt=""/>
 
-      <p>Delivered by Canonical</p>
+      <p><a class="p-link--inverted" href="https://ubuntu.com/kubeflow">Delivered by Canonical</a></p>
 
       <p class="p-footer--secondary__content u-no-margin--bottom">&copy; 2019 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
 


### PR DESCRIPTION
## Done

Add link to https://ubuntu.com/kubeflow from the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8035
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the phrase in the footer which reads "Delivered by Canonical" links to https://ubuntu.com/kubeflow


## Issue / Card

Fixes #35 