### PR TITLE
Add variable for year in copyright

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -5,7 +5,7 @@
 
       <p><a class="p-link--inverted" href="https://ubuntu.com/kubeflow">Delivered by Canonical</a></p>
 
-      <p class="p-footer--secondary__content u-no-margin--bottom">&copy; 2019 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+      <p class="p-footer--secondary__content u-no-margin--bottom">&copy; {{ current_year() }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
 
       <nav>
         <ul class="p-inline-list--middot u-no-margin--bottom">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,3 +46,13 @@ def months_list_filter(year):
         if date < now.date():
             months.append({"name": date.strftime("%b"), "number": i})
     return months
+
+from webapp.context import (
+    current_year
+)
+
+@app.context_processor
+def context():
+    return {
+        "current_year": current_year,
+    }

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -1,0 +1,4 @@
+import datetime
+
+def current_year():
+    return datetime.datetime.now().year


### PR DESCRIPTION
## Done

Add context processor to get year for the copyright date in the footer

## QA

- Download this branch
- ./run it
- look at http://0.0.0.0:8035/
- See the year 2020 in the footer

Fixes #37 