### PR TITLE
Multistage builds kubeflow-news.com

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,8 @@
 cache.sqlite
 README.md
 HACKING.md
+renovate.json
+LICENCE
 
 # The run script isn't needed
 run
@@ -19,6 +21,4 @@ run
 .env.local
 
 # Node is only needed for building, not running
-package.json
 node_modules
-yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,47 @@
-FROM ubuntu:bionic
+# syntax=docker/dockerfile:experimental
 
-# Set up environment
-ENV LANG C.UTF-8
+# Build stage: Install python dependencies
+# ===
+FROM ubuntu:focal AS python-dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools build-essential python3-dev
+ADD requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
+
+
+# Build stage: Install yarn dependencies
+# ===
+FROM node:12-slim AS yarn-dependencies
 WORKDIR /srv
+ADD package.json .
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 
-# System dependencies
-RUN apt-get update -y && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
+# Build stage: Run "yarn run build-css"
+# ===
+FROM yarn-dependencies AS build-css
+WORKDIR /srv
+COPY static/sass static/sass
+RUN yarn run build
 
-# Set git commit ID
-ARG TALISKER_REVISION_ID
-ENV TALISKER_REVISION_ID "${TALISKER_REVISION_ID}"
+# Build the production image
+# ===
+FROM ubuntu:focal
 
-# Import code, install code dependencies
+# Install python and import python dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-setuptools python3-pip build-essential python3-dev
 COPY . .
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
+COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages
+COPY --from=python-dependencies /root/.local/bin /root/.local/bin
+ENV PATH="/root/.local/bin:${PATH}"
+
+
+# Import code, build assets
+COPY . .
+RUN rm -rf package.json yarn.lock .babelrc webpack.config.js requirements.txt
+COPY --from=build-css /srv/static/css static/css
+
+# Set revision ID
+ARG BUILD_ID
+ENV TALISKER_REVISION_ID "${BUILD_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
## Done

Multistage builds to decrease image size, faster image building.

## QA

- `export DOCKER_BUILDKIT=1`
- Build image with new dockerfile `docker build --tag myimage --build-arg BUILD_ID=myfakeid .`
- Run container with this image `docker run -ti -p 8111:80 myimage`
- Check build_id `myfakeid` is present `curl localhost:8111`

## Issue / Card

Fixes #42 

