### PR TITLE
Update blog module version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-canonicalwebteam.flask-base==0.6.1
-canonicalwebteam.blog==5.0.0
+canonicalwebteam.flask_base==0.6.3
+canonicalwebteam.blog==6.2.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
     <title>{% block title %}{{ title }}{% endblock %}</title>
 
     <link rel="preconnect" href="https://assets.ubuntu.com">
+    <link rel="preconnect" href="https://res.cloudinary.com">
 
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2" crossorigin>
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2" crossorigin>
@@ -26,6 +27,8 @@
     <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/b23068a3-apple-icon.png" />
 
     <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />
+
+    <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,6 +1,7 @@
 import datetime
-from canonicalwebteam.blog import BlogViews
-from canonicalwebteam.blog.flask import build_blueprint
+import talisker.requests
+
+from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
 from canonicalwebteam.flask_base.app import FlaskBase
 
 
@@ -13,10 +14,14 @@ app = FlaskBase(
     template_500="500.html",
 )
 
+session = talisker.requests.get_session()
 
 # Blog
 blog_views = BlogViews(
-    blog_title="kubeflow-news", tag_ids=[3408], excluded_tags=[3184, 3265]
+    api=BlogAPI(session=session),
+    blog_title="kubeflow-news",
+    tag_ids=[3408],
+    excluded_tags=[3184, 3265],
 )
 
 


### PR DESCRIPTION
Update blog module version.

## QA

Browse to: https://kubeflow-news-com-61.demos.haus

Check that thumbnails are ok. Click on some articles, check the images are fine:
The urls of the images should be pointing to `ubuntu.com/wp-content` not `admin.insights.ubuntu.com/wp-content`
The cloudinary service should be enabled for both thumbnails and article images.