### PR TITLE
Change blog API URL

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,9 @@ jobs:
         run: yarn install
 
       - name: Python dependencies
-        run: sudo pip3 install black flake8
+        run: |
+          python3 -m pip install --upgrade pip
+          sudo pip3 install flake8 black
 
       - name: Lint python
         run: yarn lint-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-canonicalwebteam.flask_base==0.6.3
+canonicalwebteam.flask_base==0.6.4
 canonicalwebteam.blog==6.2.2

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -18,7 +18,9 @@ session = talisker.requests.get_session()
 
 # Blog
 blog_views = BlogViews(
-    api=BlogAPI(session=session),
+    api=BlogAPI(
+        session=session, api_url="https://ubuntu.com/blog/wp-json/wp/v2"
+    ),
     blog_title="kubeflow-news",
     tag_ids=[3408],
     excluded_tags=[3184, 3265],


### PR DESCRIPTION
Change the blog api url to `https://ubuntu.com/blog/wp-json/wp/v2/`
since admin.insights.ubuntu.com is now behind firewall and no longer can
be reached.

## QA

- Do the git actions pass? If yes than it worked.
